### PR TITLE
インポート時に文字コードを変換しない

### DIFF
--- a/app/models/issue_validator.rb
+++ b/app/models/issue_validator.rb
@@ -79,7 +79,7 @@ private
       if field.starts_with?("cf_")
         mapping_hash["custom_field_values"] = (mapping_hash["custom_field_values"] || {}).merge(field[3..-1]=>@issue_row[index])
       else
-        mapping_hash[field]= (@issue_row[index].encode("UTF-8", "ISO-8859-15") rescue @issue_row[index])
+        mapping_hash[field]= @issue_row[index]
       end
     end
     mapping_hash


### PR DESCRIPTION
## PR概要

インポート時にUTF-8→ISO-8859-15の変換処理が走らないようにする
## 背景

オリジナルではCSV取り込み時に文字コード変換が走るため、登録されたチケットのマルチバイト文字が文字化けする現象が発生する。
