### PR TITLE
名前指定時のフォーマットを"姓名"に変更

### DIFF
--- a/app/models/issue_validator.rb
+++ b/app/models/issue_validator.rb
@@ -51,8 +51,8 @@ class IssueValidator
   end
 
   def get_user(field)
-    name = @issue_row[IssueMapper.get_value(field)].split(' ') rescue nil
-    User.where("firstname = ? AND lastname = ? ",name.first,name.last).first if name
+    name = @issue_row[IssueMapper.get_value(field)]
+    User.where("lastname || firstname = ?", name).first if name
   end
 
   def issue_param_hash


### PR DESCRIPTION
## PR概要

チケットの「担当者」などにユーザを指定する場合のフォーマットを "姓名" に変更する。
- 変更前: "太郎 山田"
- 変更後: "山田太郎"
## 背景

オリジナルの仕様だと "名 姓" のフォーマットに決め打ちされている（英語圏仕様？）。
実用にあたってオリジナル仕様だと不便が大きいため変更することにしました。
## やろうと思って諦めた
- Redmine 設定の「ユーザー名の表示書式」にフォーマットを合わせる
- MySQL や sqlite3 でも動くようにする

そこまで作りこむ必要無いかと思って上の２つの実装については切り捨ててます
