### PR TITLE
カスタムフィールドが取り込めない不具合を修正

### DIFF
--- a/app/controllers/csv_imports_controller.rb
+++ b/app/controllers/csv_imports_controller.rb
@@ -102,10 +102,10 @@ private
       issue_validator = IssueValidator.new(issue, @project, params[:options])
       issue_param_hash = issue_validator.issue_param_hash
 
-      @issue=Issue.new(project: @project, created_on: issue_param_hash['created_on'], updated_on: issue_param_hash['updated_on'])
+      @issue=Issue.new(project: @project, created_on: issue_param_hash['created_on'], updated_on: issue_param_hash['updated_on'], tracker: issue_param_hash['tracker'], author: issue_param_hash['author'])
       call_hook(:controller_issues_new_before_save, { :params => issue_param_hash, :issue => @issue })
       @issue.safe_attributes = issue_param_hash
-      ['tracker', 'author'].each{|mapping| @issue.send("#{mapping}=", issue_param_hash["#{mapping}"])}
+      @issue.custom_field_values = issue_param_hash['custom_field_values']
       unless issue_validator.errors.blank? and @issue.valid?
         @issue.errors.messages.merge!(issue_validator.errors.messages)
         validation_failed = true


### PR DESCRIPTION
## PR概要

CSVインポート時にカスタムフィールドが取り込めない不具合を修正
## 不具合について詳細
- 期待する動作: CSVの特定カラムをカスタムフィールドにマッピング指定すると、登録後のチケットにて指定したカスタムフィールドに値が登録される
- 実際の振る舞い: 登録後のチケットにて指定したカスタムフィールドの値が空（エラーにはならず、登録処理自体は成功する）
