### PR TITLE
Windowsからインポートした場合のMIME Type validation を修正

### DIFF
--- a/app/models/csv_import.rb
+++ b/app/models/csv_import.rb
@@ -11,7 +11,7 @@ class CsvImport
 
   has_attached_file :csv
   validates_attachment :csv, :presence => {:message => "Oops! Please select a CSV file to import."},
-  :content_type => { :content_type => ['text/csv','text/comma-separated-values','application/csv','application/octet-stream'], :message => "Oops! Please upload a file with the extension of csv." },
+  :content_type => { :content_type => ['text/csv','text/comma-separated-values','application/csv','application/octet-stream', 'application/vnd.ms-excel'], :message => "Oops! Please upload a file with the extension of csv." },
   :size => { :greater_than => 0.kilobytes, :message => 'Oops! This file has no data. Please upload a file with some data.' }
 
   def initialize(attributes={})


### PR DESCRIPTION
## PR概要

Windows 環境から CSV をインポートしようとした際に下記のバリデーションエラーが出てインポート失敗する不具合を修正

```
Oops! Please upload a file with the extension of csv.
```
## 不具合詳細

Windows の場合、csv の MIME Type が `application/vnd.ms-excel` としてアップロードされるため、バリデーションにひっかかってアップロードに失敗する

Windows の場合

```
Started POST "/projects/hoge/csv_imports" for 127.0.0.1 at 2015-03-31 10:30:17 +0900
Processing by CsvImportsController#create as HTML
  Parameters: {"utf8"=>"✓", 
...
@content_type="application/vnd.ms-excel", 
...
 "project_id"=>"hoge"}
```

Mac の場合

```
Started POST "/projects/hoge/csv_imports" for 127.0.0.1 at 2015-03-31 10:30:17 +0900
Processing by CsvImportsController#create as HTML
  Parameters: {"utf8"=>"✓", 
...
@content_type="text/csv", 
...
 "project_id"=>"hoge"}
```

バリデーション処理は下記で設定されている

https://github.com/occ-corp/csv_import_issues/blob/518267c69ede74047e20d36b74372984733b7fe2/app/models/csv_import.rb#L14

以下、抜粋

``` ruby
:content_type => 
  { :content_type => 
    ['text/csv',
     'text/comma-separated-values',
     'application/csv',
     'application/octet-stream'], 
    :message => "Oops! Please upload a file with the extension of csv." },
```
